### PR TITLE
💪🏾   Drop net6.0 support

### DIFF
--- a/.nuke/build.schema.json
+++ b/.nuke/build.schema.json
@@ -90,8 +90,11 @@
           "description": "Shows the execution plan (HTML)"
         },
         "Profile": {
-          "type": "string",
-          "description": "Name of the profile where the current set of secrets"
+          "type": "array",
+          "description": "Defines the profiles to load",
+          "items": {
+            "type": "string"
+          }
         },
         "Root": {
           "type": "string",
@@ -110,7 +113,6 @@
               "Compile",
               "Feature",
               "Hotfix",
-              "ManageSecrets",
               "MutationTests",
               "Pack",
               "Publish",
@@ -143,7 +145,6 @@
               "Compile",
               "Feature",
               "Hotfix",
-              "ManageSecrets",
               "MutationTests",
               "Pack",
               "Publish",

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -9,10 +9,11 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 ### 🚨 Breaking changes
 
 - Dropped `net5.0` support ([#119](https://github.com/candoumbe/DataFilters.AspNetCore/issues/119))
+- Dropped `net6.0` support ([#197](https://github.com/candoumbe/DataFilters.AspnetCore/issues/197))
 
 ### 🧹 Housekeeping
 
-- Replaced Moq with Nsubstitute ([#117](https://github.com/candoumbe/DataFilters.AspNetCore/issues/117))
+- Replaced Moq with NSubstitute ([#117](https://github.com/candoumbe/DataFilters.AspNetCore/issues/117))
 - Fixed broken status badges ([#118](https://github.com/candoumbe/DataFilters.AspNetCore/issues/118))
 - Updated CI/CD to use [Candoumbe.Pipelines](https://nuget.org/packages/Candoumbe.Pipelines)
 

--- a/global.json
+++ b/global.json
@@ -1,3 +1,6 @@
 {
-  "sdk": {"version": "6.0.428"}
+  "sdk": {
+    "version": "8.0.101",
+    "rollForward": "latestMinor"
+  }
 }

--- a/src/DataFilters.AspNetCore/DataFilters.AspNetCore.csproj
+++ b/src/DataFilters.AspNetCore/DataFilters.AspNetCore.csproj
@@ -3,7 +3,7 @@
   <Import Project="..\..\core.props" />
 
   <PropertyGroup>
-    <TargetFrameworks>netstandard2.1;net6.0</TargetFrameworks>
+    <TargetFrameworks>net8.0</TargetFrameworks>
     <PackageTags>datafilters; filtering; filter; ifilter; </PackageTags>
     <PackageRequireLicenseAcceptance>True</PackageRequireLicenseAcceptance>
   </PropertyGroup>

--- a/test/DataFilters.AspNetCore.Attributes.UnitTests/DataFilters.AspNetCore.Attributes.UnitTests.csproj
+++ b/test/DataFilters.AspNetCore.Attributes.UnitTests/DataFilters.AspNetCore.Attributes.UnitTests.csproj
@@ -2,7 +2,7 @@
 
   <Import Project="..\..\tests.props" />
   <PropertyGroup>
-    <TargetFrameworks>net6.0</TargetFrameworks>
+    <TargetFrameworks>net8.0</TargetFrameworks>
   </PropertyGroup>
 
   <ItemGroup>

--- a/test/DataFilters.AspNetCore.PerformanceTests/DataFilters.AspNetCore.PerformanceTests.csproj
+++ b/test/DataFilters.AspNetCore.PerformanceTests/DataFilters.AspNetCore.PerformanceTests.csproj
@@ -2,7 +2,7 @@
 
   <PropertyGroup>
     <OutputType>Exe</OutputType>
-    <TargetFramework>net6.0</TargetFramework>
+    <TargetFramework>net8.0</TargetFramework>
   </PropertyGroup>
 
   <ItemGroup>

--- a/test/DataFilters.AspNetCore.UnitTests/DataFilters.AspNetCore.UnitTests.csproj
+++ b/test/DataFilters.AspNetCore.UnitTests/DataFilters.AspNetCore.UnitTests.csproj
@@ -2,7 +2,7 @@
 
   <Import Project="..\..\tests.props" />
   <PropertyGroup>
-    <TargetFrameworks>net6.0</TargetFrameworks>
+    <TargetFrameworks>net8.0</TargetFrameworks>
   </PropertyGroup>
   <ItemGroup>
     <PackageReference Include="Microsoft.AspNetCore.Http.Abstractions" Version="2.2.0" />


### PR DESCRIPTION
### 🚨 Breaking changes

- Dropped `net5.0` support ([#119](https://github.com/candoumbe/DataFilters.AspNetCore/issues/119))
- Dropped `net6.0` support ([#197](https://github.com/candoumbe/DataFilters.AspnetCore/issues/197))

### 🧹 Housekeeping

- Replaced Moq with NSubstitute ([#117](https://github.com/candoumbe/DataFilters.AspNetCore/issues/117))
- Fixed broken status badges ([#118](https://github.com/candoumbe/DataFilters.AspNetCore/issues/118))
- Updated CI/CD to use [Candoumbe.Pipelines](https://nuget.org/packages/Candoumbe.Pipelines)

Resolves #119 , #197 