### PR TITLE
🧹 Minimal Attribute Should Not Activate When Headers Is Incorrect Or Absent

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -6,10 +6,12 @@ The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/),
 and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
 
 ## [Unreleased]
-### 🚨 Breaking changes
-
+### 💥 Breaking changes
 - Dropped `net5.0` support ([#119](https://github.com/candoumbe/DataFilters.AspNetCore/issues/119))
 - Dropped `net6.0` support ([#197](https://github.com/candoumbe/DataFilters.AspnetCore/issues/197))
+
+### 🚨 Fixes
+- Made detecting supported requests for `PreferMinimalActionFilterAttribute` more reliable
 
 ### 🧹 Housekeeping
 
@@ -25,6 +27,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 - Added `MinimalAttribute` to support `Prefer: return=minimal` HTTP header ([#47](https://github.com/candoumbe/DataFilters.AspNetCore/issues/47)) 
 
 ## [0.2.0] / 2022-03-29
+### 🧹 Housekeeping
 - Bumped [`Candoumbe.MiscUtilities`](https://nuget.org/packages/Candoumbe.MiscUtilities) to [`0.6.3`](https://nuget.org/packages/Candoumbe.DataFilters/0.8.0)
 - Bumped [`DataFilters`](https://nuget.org/packages/DataFilters) to [`0.11.0`](https://nuget.org/packages/Candoumbe/DataFilters/0.8.0)
 - Dropped `FluentAssertions` dependency

--- a/README.md
+++ b/README.md
@@ -96,7 +96,7 @@ To enable support of the `Prefer: return=minimal` HTTP header :
 ```csharp
 services.Filters.Add(new PreferActionFilterAttribute());
 ```
-2. Annotate properties in your classes with [MinimalAttribute][cls-attrs-minimal].
+2. Annotate properties in your classes with [MinimalAttribute][cls-attrs-minimal]: those properties will be the only ones sent when a client requests a minimal representation of the resource.
 3. Send a request with `Prefer` header to the API and you should get responses that conforms to your settings.
 
 

--- a/src/DataFilters.AspNetCore/Filters/PreferMinimalActionFilterAttribute.cs
+++ b/src/DataFilters.AspNetCore/Filters/PreferMinimalActionFilterAttribute.cs
@@ -3,6 +3,7 @@
 
 namespace DataFilters.AspNetCore.Filters;
 
+using System;
 using DataFilters.AspNetCore.Attributes;
 
 using Microsoft.AspNetCore.Mvc;
@@ -12,7 +13,7 @@ using System.Collections.Generic;
 using System.Dynamic;
 using System.Linq;
 using System.Reflection;
-
+using Microsoft.AspNetCore.Http;
 using static Microsoft.AspNetCore.Http.HttpMethods;
 
 /// <summary>
@@ -26,20 +27,28 @@ public class PreferMinimalActionFilterAttribute : ActionFilterAttribute
     /// </summary>
     public const string PreferHeaderName = "Prefer";
 
+    private const string PreferHeaderReturnMinimal = "return=minimal";
+
     ///<inheritdoc/>
     public override void OnActionExecuted(ActionExecutedContext context)
     {
-        if (CanHandleRequest(context.HttpContext.Request.Method) && context.Result is OkObjectResult result)
+        if (CanHandleRequest(context.HttpContext.Request) && context.Result is OkObjectResult result)
         {
             ExpandoObject expando = ExtractProperties(result.Value);
 
             context.Result = new OkObjectResult(expando);
         }
 
-        static bool CanHandleRequest(in string method) => IsGet(method)
-                                                       || IsPost(method)
-                                                       || IsPatch(method)
-                                                       || IsPut(method);
+        static bool CanHandleRequest(in HttpRequest request) => IsMethodSupported(request.Method) && HasRequiredHeaders(request.Headers);
+
+        static bool IsMethodSupported(in string method) => IsGet(method)
+                                                           || IsPost(method)
+                                                           || IsPatch(method)
+                                                           || IsPut(method);
+
+        static bool HasRequiredHeaders(in IHeaderDictionary headers) => headers.ContainsKey(PreferHeaderName)
+                                                                        && headers[PreferHeaderName].Exactly(1)
+                                                                        && string.Equals(headers[PreferHeaderName].Single(), PreferHeaderReturnMinimal, StringComparison.OrdinalIgnoreCase);
 
         static ExpandoObject ExtractProperties(object obj)
         {

--- a/test/DataFilters.AspNetCore.UnitTests/Filters/PreferMinimalActionFilterAttributeTests.cs
+++ b/test/DataFilters.AspNetCore.UnitTests/Filters/PreferMinimalActionFilterAttributeTests.cs
@@ -17,7 +17,7 @@
     using System.Collections.Generic;
     using System.Dynamic;
     using System.Linq.Expressions;
-
+    using FluentAssertions.Equivalency.Tracing;
     using Xunit;
     using Xunit.Abstractions;
     using Xunit.Categories;
@@ -28,10 +28,12 @@
     public class PreferMinimalActionFilterAttributeTests
     {
         private readonly ITestOutputHelper _outputHelper;
+        private readonly PreferMinimalActionFilterAttribute _sut;
 
         public PreferMinimalActionFilterAttributeTests(ITestOutputHelper outputHelper)
         {
             _outputHelper = outputHelper;
+            _sut = new PreferMinimalActionFilterAttribute();
         }
 
         [Fact]
@@ -55,11 +57,11 @@
             get
             {
                 StringValues preferHeaderValue = new("return=minimal");
-                string[] methods = { Get, Post, Put, Patch };
+                string[] methods = [Get, Post, Put, Patch];
                 foreach (string method in methods)
                 {
-                    yield return new object[]
-                    {
+                    yield return
+                    [
                         method,
                         new HeaderDictionary(new Dictionary<string, StringValues>
                         {
@@ -71,7 +73,7 @@
                                                                            && expando.Once(kv => kv.Key == nameof(FooWithMinimalProps.Baz))
                                                                ),
                         $"The filter is configured to support HTTP verb '{method}' is supported and '{PreferMinimalActionFilterAttribute.PreferHeaderName}' header is set to {preferHeaderValue}"
-                    };
+                    ];
                 }
             }
         }
@@ -85,8 +87,10 @@
                                                                                                                                                                            string reason)
         {
             // Arrange
-            DefaultHttpContext httpContext = new();
-            httpContext.Request.Method = method;
+            DefaultHttpContext httpContext = new()
+            {
+                Request = { Method = method }
+            };
             headers.ForEach(header => httpContext.Request.Headers.TryAdd(header.Key, header.Value));
 
             ActionContext actionContext = new(
@@ -102,10 +106,8 @@
                 Result = new OkObjectResult(actual)
             };
 
-            PreferMinimalActionFilterAttribute sut = new();
-
             // Act
-            sut.OnActionExecuted(actionExecutedContext);
+            _sut.OnActionExecuted(actionExecutedContext);
 
             // Assert
             IActionResult result = actionExecutedContext.Result;
@@ -115,7 +117,78 @@
                   .Should().Match(expectedResult, reason);
         }
 
-        internal record FooWithMinimalProps
+        public static TheoryData<string, IHeaderDictionary, object, object, string> MissingOrIncorrectHeaderCases
+        {
+            get
+            {
+                (StringValues preferHeaderValues, string reason)[] preferHeaderValuesAndReason =  [
+                    (new StringValues(),  "The header as no value set"),
+                    (new StringValues("return=representation"), "The header's value is `representation` which should not activate the filter."),
+                    (new StringValues(["return=representation", "return=minimal"]), "The header has both minimal and representation values")
+                ];
+                string[] methods = [Get, Post, Put, Patch];
+
+                TheoryData<string, IHeaderDictionary, object, object, string> cases = new();
+
+                foreach ((StringValues preferHeaderValue, string reason) in preferHeaderValuesAndReason)
+                {
+                    foreach (string method in methods)
+                    {
+                        cases.Add(
+                            method,
+                            new HeaderDictionary(new Dictionary<string, StringValues>
+                            {
+                                [PreferMinimalActionFilterAttribute.PreferHeaderName] = preferHeaderValue
+                            }),
+                            new FooWithMinimalProps(),
+                            new FooWithMinimalProps(),
+                            reason
+                        );
+                    }
+                }
+
+                return cases;
+            }
+        }
+
+        [Theory]
+        [MemberData(nameof(MissingOrIncorrectHeaderCases))]
+        public void Given_request_with_Prefer_header_When_Prefer_header_is_not_present_or_has_incorrect_value__Then_attribute_not_do_anything(string method,
+                                                                                                                                              IHeaderDictionary headers,
+                                                                                                                                              object actual,
+                                                                                                                                              object expected,
+                                                                                                                                              string reason)
+        {
+            // Arrange
+            DefaultHttpContext httpContext = new()
+            {
+                Request = { Method = method }
+            };
+            headers.ForEach(header => httpContext.Request.Headers.TryAdd(header.Key, header.Value));
+
+            ActionContext actionContext = new(
+               httpContext,
+               Substitute.For<RouteData>(),
+               Substitute.For<ActionDescriptor>(),
+               new ModelStateDictionary());
+
+            ActionExecutedContext actionExecutedContext = new(actionContext, filters: [], controller: Substitute.For<object>())
+            {
+                Result = new OkObjectResult(actual)
+            };
+
+            // Act
+            _sut.OnActionExecuted(actionExecutedContext);
+
+            // Assert
+            IActionResult result = actionExecutedContext.Result;
+
+            result.Should()
+                  .BeAssignableTo<ObjectResult>().Which.Value
+                  .Should().BeEquivalentTo(expected);
+        }
+
+        private record FooWithMinimalProps
         {
             [Minimal]
             public string Prop1 { get; set; } = nameof(Prop1);
@@ -123,7 +196,7 @@
             public Baz Baz { get; set; } = new();
         }
 
-        internal record Baz
+        private record Baz
         {
             public string Prop1 { get; set; } = nameof(Prop1);
 


### PR DESCRIPTION
### 🚨 Breaking changes
• Dropped net5.0 support ([#119](https://github.com/candoumbe/DataFilters.AspNetCore/issues/119))
• Dropped net6.0 support ([#197](https://github.com/candoumbe/DataFilters.AspnetCore/issues/197))
### 🧹 Housekeeping
• Replaced Moq with NSubstitute ([#117](https://github.com/candoumbe/DataFilters.AspNetCore/issues/117))
• Fixed broken status badges ([#118](https://github.com/candoumbe/DataFilters.AspNetCore/issues/118))
• Updated CI/CD to use [Candoumbe.Pipelines](https://nuget.org/packages/Candoumbe.Pipelines)

Full changelog at https://github.com/candoumbe/DataFilters.AspNetCore/blob/coldfix/minimal-attribute-should-not-activate-when-headers-is-incorrect-or-absent/CHANGELOG.md