### PR TITLE
💪🏾 add Configuration To Publish Nuget Packages

### DIFF
--- a/.github/workflows/continuous.yml
+++ b/.github/workflows/continuous.yml
@@ -42,8 +42,8 @@ jobs:
             .nuke/temp
             ~/.nuget/packages
           key: ${{ runner.os }}-${{ hashFiles('global.json', 'src/**/*.csproj') }}
-      - name: 'Run: UnitTests, ReportUnitTestCoverage, Pack'
-        run: ./build.cmd UnitTests ReportUnitTestCoverage Pack
+      - name: 'Run: UnitTests, MutationTests, ReportUnitTestCoverage, Pack, Publish'
+        run: ./build.cmd UnitTests MutationTests ReportUnitTestCoverage Pack Publish
         env:
           NuGetApiKey: ${{ secrets.NUGET_API_KEY }}
           CodecovToken: ${{ secrets.CODECOV_TOKEN }}

--- a/.nuke/parameters.local.json
+++ b/.nuke/parameters.local.json
@@ -1,6 +1,8 @@
 {
-  "GitHubToken": "v1:g53mFMH6PyC+NZYQX9m5jPKImeC257+le5wcN6RTxIa/C6hm3EDPLsh6CtQNQnWLuiUL49d7WuyV0OZS/UyOMMFW5CRgRRZC/tUaoqiJPnucmbMuPgF931dbL3dou6lz",
-  "NugetApiKey": "v1:Z2RAWjPeRgFploGorSP8GMqC66P78vCXjZwETIBkZY+3eqnVxDilBReLnDCEtI7/",
-  "StrykerDashboardApiKey": "v1:JEQsijbvz6iEqdu70EPaA6aIXfp7lyh4HCozze9AWwl+Dd9og5eNJXRrn41HSoD2",
-  "CodecovToken": "v1:TvPOE55QwGcB9cSHbELON5bZkYbXo74Nu6xSb8vy37is/K9v200Mu/HQ9CsVkzoQ"
+  "$schema": "./build.schema.json",
+  "CodecovToken": "v1:jKm6SB/2MC0mZ+lINXAUoMxgOSMClrASR43BWHFStTM7bXViAkILMtrsvW0R34Y5",
+  "GitHubToken": "v1:VagR7Ay2Nm6iZYyilV+0V0xqy+bFwO8ykT9W2yWehyj2u7u7eA7Ysmtek7DpGkVMdKOjZkiJwdap8wkRuxswIycMjtzhMtRlVOb37rDfwqwxg+V7h7h/iHEFAb+TMiXd",
+  "NuGetApiKey": "v1:CjatUOqJ+HHtB7Echzq+bgIx/gMWHaF/YAeG4NUwb24XBz0BEUvb1lgV7Oid/IWT",
+  "StrykerDashboardApiKey": "v1:srmQzUbTe8aLkvevoBvTrBtfioJHzq//mgFVeTkIVUGNLT7FSM96eXmBE/lH5emo",
+  "DeleteLocalOnSuccess": true
 }

--- a/Directory.Packages.props
+++ b/Directory.Packages.props
@@ -8,7 +8,7 @@
   </ItemGroup>
   <ItemGroup>
     <PackageVersion Include="BenchmarkDotNet" Version="0.15.2" />
-    <PackageVersion Include="Candoumbe.Pipelines" Version="1.2.1-fix.2" />
+    <PackageVersion Include="Candoumbe.Pipelines" Version="1.2.1-fix.5" />
     <PackageVersion Include="CodecovUploader" Version="0.8.0" />
     <PackageVersion Include="coverlet.msbuild" Version="6.0.4" />
     <PackageVersion Include="DataFilters" Version="0.13.1" />

--- a/build/Build.cs
+++ b/build/Build.cs
@@ -10,10 +10,10 @@ using Nuke.Common.CI.GitHubActions;
 using Nuke.Common.IO;
 using Nuke.Common.ProjectModel;
 using Nuke.Common.Tooling;
+using Nuke.Common.Tools.GitHub;
 using Nuke.Common.Tools.ReportGenerator;
 
 namespace DataFilters.ContinuousIntegration;
-
 
 [GitHubActions(
                   "continuous",
@@ -22,7 +22,14 @@ namespace DataFilters.ContinuousIntegration;
                   FetchDepth = 0,
                   OnPushBranchesIgnore = [nameof(IGitFlow.MainBranchName)],
                   PublishArtifacts = true,
-                  InvokedTargets = [nameof(IUnitTest.UnitTests), nameof(IReportUnitTestCoverage.ReportUnitTestCoverage), nameof(IPack.Pack)],
+                  InvokedTargets =
+                  [
+                      nameof(IUnitTest.UnitTests),
+                      nameof(IMutationTest.MutationTests),
+                      nameof(IReportUnitTestCoverage.ReportUnitTestCoverage),
+                      nameof(IPack.Pack),
+                      nameof(IPushNugetPackages.Publish)
+                  ],
                   CacheKeyFiles = ["global.json", "src/**/*.csproj"],
                   ImportSecrets =
                   [
@@ -62,7 +69,6 @@ namespace DataFilters.ContinuousIntegration;
                       "LICENSE"
                   ]
               )]
-
 [GitHubActions(
                   "nightly-manual",
                   GitHubActionsImage.UbuntuLatest,
@@ -75,7 +81,6 @@ namespace DataFilters.ContinuousIntegration;
                   PublishArtifacts = true,
                   ImportSecrets = [nameof(IMutationTest.StrykerDashboardApiKey)]
               )]
-
 public class Build : EnhancedNukeBuild,
     IHaveSourceDirectory,
     IHaveTestDirectory,
@@ -91,11 +96,14 @@ public class Build : EnhancedNukeBuild,
 {
     public static int Main() => Execute<Build>(x => ((ICompile)x).Compile);
 
-    [Required][Solution] public Solution Solution;
+    [Required] [Solution] public Solution Solution;
 
     ///<inheritdoc/>
-    IEnumerable<AbsolutePath> IClean.DirectoriesToDelete => this.Get<IHaveSourceDirectory>().SourceDirectory.GlobDirectories("**/bin", "**/obj")
-        .Concat(this.Get<IHaveTestDirectory>().TestDirectory.GlobDirectories("**/bin", "**/obj"));
+    IEnumerable<AbsolutePath> IClean.DirectoriesToDelete =>
+    [
+        .. this.Get<IHaveSourceDirectory>().SourceDirectory.GlobDirectories("**/bin", "**/obj"),
+        .. this.Get<IHaveTestDirectory>().TestDirectory.GlobDirectories("**/bin", "**/obj")
+    ];
 
     ///<inheritdoc/>
     Solution IHaveSolution.Solution => Solution;
@@ -107,7 +115,18 @@ public class Build : EnhancedNukeBuild,
     IEnumerable<AbsolutePath> IPack.PackableProjects => this.Get<IHaveSourceDirectory>().SourceDirectory.GlobFiles("*.csproj");
 
     ///<inheritdoc/>
-    IEnumerable<PushNugetPackageConfiguration> IPushNugetPackages.PublishConfigurations => throw new NotImplementedException();
+    IEnumerable<PushNugetPackageConfiguration> IPushNugetPackages.PublishConfigurations =>
+    [
+        new NugetPushConfiguration(
+                                   apiKey: this.As<IPushNugetPackages>()?.NuGetApiKey,
+                                   source: new Uri("https://api.nuget.org/v3/index.json"),
+                                   canBeUsed: () => this.As<IPushNugetPackages>()?.NuGetApiKey is not null
+                                  ),
+        new GitHubPushNugetConfiguration(
+                                         githubToken: this.Get<ICreateGithubRelease>()?.GitHubToken,
+                                         source: new Uri($"https://nuget.pkg.github.com/{this.Get<IHaveGitHubRepository>().GitRepository.GetGitHubOwner()}/index.json"),
+                                         canBeUsed: () => this is ICreateGithubRelease { GitHubToken: not null })
+    ];
 
     ///<inheritdoc/>
     bool IReportCoverage.ReportToCodeCov => this.Get<IReportCoverage>().CodecovToken is not null;


### PR DESCRIPTION
### 💥 Breaking changes
• Dropped net5.0 support ([#119](https://github.com/candoumbe/DataFilters.AspNetCore/issues/119))
• Dropped net6.0 support ([#197](https://github.com/candoumbe/DataFilters.AspNetCore/issues/197))
### 🚨 Fixes
• Activate Prefer filter only when required headers are present
### 🧹 Housekeeping
• Replaced Moq with NSubstitute ([#117](https://github.com/candoumbe/DataFilters.AspNetCore/issues/117))
• Fixed broken status badges ([#118](https://github.com/candoumbe/DataFilters.AspNetCore/issues/118))
• Migrated CI/CD to use [Candoumbe.Pipelines](https://nuget.org/packages/Candoumbe.Pipelines)
• Adopted central package management
• Added Roslynator and SonarAnalyzer analyzers
• Harmonized coding style

Full changelog at https://github.com/candoumbe/DataFilters.AspNetCore/blob/chore/add-configuration-to-publish-nuget-packages/CHANGELOG.md